### PR TITLE
[Craft 5.x] Remove source message from queue progress

### DIFF
--- a/src/jobs/BulkTranslateJob.php
+++ b/src/jobs/BulkTranslateJob.php
@@ -26,7 +26,7 @@ class BulkTranslateJob extends BaseJob
 
         foreach ($sourceMessages as $i => $sourceMessage) {
             $iHuman = $i+1;
-            $this->setProgress($queue, $i/$totalCount, "Translating line $iHuman/$totalCount ($sourceMessage->message)");
+            $this->setProgress($queue, $i/$totalCount, "Translating line $iHuman/$totalCount");
 
             if ($this->sourceLocale == 'message') {
                 $sourceText = $sourceMessage->message;


### PR DESCRIPTION
This fixes an issue where if the source message key in a static template was over 255 characters long it would crash the job due to the `queue_hashed` table having a limit of 255 chars on the `progressLabel` field.

Because we use the default (for us) English strings as the translation key in our static templates we've run into this pretty quickly on longer paragraphs of text or strings with some HTML in them.

![image](https://github.com/user-attachments/assets/d0ce56f4-4432-45e6-8569-aebb8cb702e1)

I had considered truncating the string but I noticed that the same `BulkTranslateJob` in `craft-multi-translator` handled this by just not showing a preview which I think works here too.